### PR TITLE
Pass state to ana/analyze-file

### DIFF
--- a/modules/metagetta/deps.edn
+++ b/modules/metagetta/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
         org.clojure/tools.namespace {:mvn/version "0.3.1"}
-        org.clojure/clojurescript {:mvn/version "1.10.520"}}
+        org.clojure/clojurescript {:mvn/version "1.10.773"}}
  :aliases {:test
             {:extra-paths ["test" "test-sources"]
              :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-554"}

--- a/modules/metagetta/src/cljdoc_analyzer/metagetta/clojurescript.clj
+++ b/modules/metagetta/src/cljdoc_analyzer/metagetta/clojurescript.clj
@@ -109,7 +109,7 @@
      ;; The 'with-core-cljs' wrapping function ensures the namespace 'cljs.core'
      ;; is available under the sub-call to 'analyze-file'.
      ;; https://github.com/cljdoc/cljdoc/issues/261
-     (comp/with-core-cljs state nil #(ana/analyze-file file)))
+     (comp/with-core-cljs state nil #(ana/analyze-file state file nil)))
     state))
 
 (defn- read-file [source-path js-dependencies file exception-handler]

--- a/src/cljdoc_analyzer/deps.clj
+++ b/src/cljdoc_analyzer/deps.clj
@@ -9,7 +9,7 @@
 
 (defn- ensure-recent-ish [deps-map]
   (let [min-versions {'org.clojure/clojure "1.9.0"
-                      'org.clojure/clojurescript "1.10.339"
+                      'org.clojure/clojurescript "1.10.773"
                       'org.clojure/java.classpath "0.2.2"
                       'org.clojure/core.async "0.4.474"}
         choose-version (fn choose-version [given-v min-v]
@@ -22,7 +22,7 @@
 
 (defn- ensure-required-deps [deps-map]
   (merge {'org.clojure/clojure {:mvn/version "1.10.1"}
-          'org.clojure/clojurescript {:mvn/version "1.10.520"}
+          'org.clojure/clojurescript {:mvn/version "1.10.773"}
           ;; many ring libraries implicitly depend on this and getting all
           ;; downstream libraries to properly declare it as a "provided"
           ;; dependency would be a major effort. since it's all java it also


### PR DESCRIPTION
The implementation of ana/analyze-file will bind a new state if it's not
provided to it explicitly.  If this is not provided, then the
js-dependency-index will not be set and cannot be searched for npm deps
like "react", etc.