### PR TITLE
Show metagetta errors on stderr

### DIFF
--- a/src/cljdoc_analyzer/runner.clj
+++ b/src/cljdoc_analyzer/runner.clj
@@ -124,7 +124,9 @@
           process (sh/sh "java"
                          "-cp" classpath
                          "-Dclojure.spec.skip-macros=true"
-                         "clojure.main" "-m" "cljdoc-analyzer.metagetta.main"
+                         "-Dclojure.main.report=stderr"
+                         "clojure.main"
+                         "-m" "cljdoc-analyzer.metagetta.main"
                          (pr-str analysis-args)
                          ;; supplying :dir is necessary to avoid local deps.edn being included
                          ;; once -Srepro is finalized it might be useful for this purpose


### PR DESCRIPTION
metagetta is often run in environments where the .edn file cannot be
recovered (e.g. circleci).  So running it to write to stderr aids
debugging, without having to re-run locally to see the error.