### PR TITLE
Add failing test for unknown tagged literal

### DIFF
--- a/modules/metagetta/deps.edn
+++ b/modules/metagetta/deps.edn
@@ -3,7 +3,7 @@
         org.clojure/tools.namespace {:mvn/version "1.0.0"}
         org.clojure/clojurescript {:mvn/version "1.10.773"}}
  :aliases {:test
-            {:extra-paths ["test" "test-sources"]
+            {:extra-paths ["test" "test-sources" "test-sources-special"]
              :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.681"}
                           lambdaisland/kaocha-junit-xml {:mvn/version "0.0.76"}}
              :main-opts ["-m" "kaocha.runner"]}

--- a/modules/metagetta/deps.edn
+++ b/modules/metagetta/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
+        org.clojure/tools.logging {:mvn/version "1.1.0"}
         org.clojure/tools.namespace {:mvn/version "1.0.0"}
         org.clojure/clojurescript {:mvn/version "1.10.773"}}
  :aliases {:test

--- a/modules/metagetta/deps.edn
+++ b/modules/metagetta/deps.edn
@@ -1,10 +1,11 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        org.clojure/tools.logging {:mvn/version "1.1.0"}
         org.clojure/tools.namespace {:mvn/version "1.0.0"}
         org.clojure/clojurescript {:mvn/version "1.10.773"}}
  :aliases {:test
-            {:extra-paths ["test" "test-sources" "test-sources-special"]
+            {:extra-paths ["test"                  ;; test code
+                           "test-sources"          ;; test namespaces to load (loading all of them at once)
+                           "test-sources-special"] ;; special test cases; only ever loads a single ns, specific for the test
              :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.681"}
                           lambdaisland/kaocha-junit-xml {:mvn/version "0.0.76"}}
              :main-opts ["-m" "kaocha.runner"]}

--- a/modules/metagetta/src/cljdoc_analyzer/metagetta/clojure.clj
+++ b/modules/metagetta/src/cljdoc_analyzer/metagetta/clojure.clj
@@ -104,8 +104,9 @@
     (typecheck-namespace namespace))
   (try
     (binding [*default-data-reader-fn* (fn [tag value]
+                                         ;; NOTE: It seems this must not return `nil`
                                          (warn-unknown-tagged-literal-once namespace tag)
-                                         nil)]
+                                         (tagged-literal tag value))]
       (require namespace)) ; FIXME warning logged yet still exc thrown at this line
     (-> (find-ns namespace)
         (meta)

--- a/modules/metagetta/src/cljdoc_analyzer/metagetta/clojure.clj
+++ b/modules/metagetta/src/cljdoc_analyzer/metagetta/clojure.clj
@@ -3,7 +3,6 @@
   (:import java.util.jar.JarFile
            java.io.FileNotFoundException)
   (:require [clojure.java.io :as io]
-            [clojure.tools.logging :as log]
             [clojure.tools.namespace.find :as ns]
             [cljdoc-analyzer.metagetta.utils :as utils]))
 
@@ -93,21 +92,13 @@
          (remove (partial protocol-method? vars))
          (map (partial read-var source-path vars)))))
 
-(defn- warn-unknown-tagged-literal [namespace tag]
-  (log/info "Beware: ns " namespace " includes the unknown tagged literal `" tag "`, ignoring it and replacing the value with nil. This should not influence the analysis unless the value is a top-level public var."))
-
-(def warn-unknown-tagged-literal-once (memoize warn-unknown-tagged-literal))
-
 (defn- read-ns [namespace source-path exception-handler]
   (try-require 'clojure.core.typed.check)
   (when (core-typed?)
     (typecheck-namespace namespace))
   (try
-    (binding [*default-data-reader-fn* (fn [tag value]
-                                         ;; NOTE: It seems this must not return `nil`
-                                         (warn-unknown-tagged-literal-once namespace tag)
-                                         (tagged-literal tag value))]
-      (require namespace)) ; FIXME warning logged yet still exc thrown at this line
+    (binding [*default-data-reader-fn* (utils/new-failsafe-data-reader-fn namespace)]
+      (require namespace))
     (-> (find-ns namespace)
         (meta)
         (select-keys [:doc :author :deprecated :added :no-doc :skip-wiki])

--- a/modules/metagetta/src/cljdoc_analyzer/metagetta/clojurescript.clj
+++ b/modules/metagetta/src/cljdoc_analyzer/metagetta/clojurescript.clj
@@ -5,6 +5,8 @@
             [cljs.closure]
             [cljs.compiler.api :as comp]
             [cljs.env]
+            ;[cljs.tools.reader :as reader]
+            [clojure.tools.reader :as reader]
             [clojure.set]
             [cljdoc-analyzer.metagetta.utils :as utils]))
 
@@ -116,7 +118,8 @@
      ;; The 'with-core-cljs' wrapping function ensures the namespace 'cljs.core'
      ;; is available under the sub-call to 'analyze-file'.
      ;; https://github.com/cljdoc/cljdoc/issues/261
-     (comp/with-core-cljs state nil #(ana/analyze-file state file nil)))
+     (binding [reader/*default-data-reader-fn* tagged-literal]
+       (comp/with-core-cljs state nil #(ana/analyze-file state file nil))))
     state))
 
 (defn- read-file [source-path js-dependencies file exception-handler]

--- a/modules/metagetta/src/cljdoc_analyzer/metagetta/clojurescript.clj
+++ b/modules/metagetta/src/cljdoc_analyzer/metagetta/clojurescript.clj
@@ -5,7 +5,6 @@
             [cljs.closure]
             [cljs.compiler.api :as comp]
             [cljs.env]
-            ;[cljs.tools.reader :as reader]
             [clojure.tools.reader :as reader]
             [clojure.set]
             [cljdoc-analyzer.metagetta.utils :as utils]))
@@ -118,7 +117,7 @@
      ;; The 'with-core-cljs' wrapping function ensures the namespace 'cljs.core'
      ;; is available under the sub-call to 'analyze-file'.
      ;; https://github.com/cljdoc/cljdoc/issues/261
-     (binding [reader/*default-data-reader-fn* tagged-literal]
+     (binding [reader/*default-data-reader-fn* (utils/new-failsafe-data-reader-fn file)]
        (comp/with-core-cljs state nil #(ana/analyze-file state file nil))))
     state))
 

--- a/modules/metagetta/src/cljdoc_analyzer/metagetta/utils.clj
+++ b/modules/metagetta/src/cljdoc_analyzer/metagetta/utils.clj
@@ -125,3 +125,18 @@
                          (tagged-literal 'regex (str %))
                          %))
        (pr-str)))
+
+(defn new-failsafe-data-reader-fn
+  "Return a new failsafe data reader that replaces unknown tagged literals with data via
+  `clojure.core/tagged-literal` instead of failing the analysis."
+  [ns-or-file]
+  (let [warn-unknown-tagged-literal
+        (fn [tag]
+          (println "INFO [metagetta.utils] Beware: ns/file " ns-or-file " includes the unknown tagged literal `" tag "`, ignoring it and replacing the value with data. This should not influence the analysis unless the value is a top-level public var."))
+
+        warn-unknown-tagged-literal-once
+        (memoize warn-unknown-tagged-literal)]
+
+    (fn failsafe-data-reader-fn [tag value]
+      (warn-unknown-tagged-literal-once tag)
+      (tagged-literal tag value))))

--- a/modules/metagetta/test-sources-special/metagetta_test_special/unknown_tagged_literal.cljc
+++ b/modules/metagetta/test-sources-special/metagetta_test_special/unknown_tagged_literal.cljc
@@ -1,0 +1,4 @@
+(ns metagetta-test-special.unknown-tagged-literal)
+
+;; Use an unknown tagged literal and see what it does to the analysis
+(def some-data #uknown-tagged-literal {})

--- a/modules/metagetta/test/cljdoc_analyzer/metagetta/main_test.clj
+++ b/modules/metagetta/test/cljdoc_analyzer/metagetta/main_test.clj
@@ -1,4 +1,5 @@
 (ns cljdoc-analyzer.metagetta.main-test
+  "Load all `test-sources/*` namespaces and test various things about them."
   (:require [clojure.test :as t]
             [cljdoc-analyzer.metagetta.main :as main]))
 

--- a/modules/metagetta/test/cljdoc_analyzer/metagetta/main_test.clj
+++ b/modules/metagetta/test/cljdoc_analyzer/metagetta/main_test.clj
@@ -172,7 +172,9 @@
                  :file "metagetta_test/test_ns1/special_tags.cljc"
                  :line 21}])})))
 
-(defn- analyze-sources [opts]
+(defn- analyze-sources
+  "Analyze (by default all) sources from `test-sources`"
+  [opts]
   (main/get-metadata (merge opts {:root-path "test-sources"})))
 
 (t/deftest analyze-cljs-code-test

--- a/modules/metagetta/test/cljdoc_analyzer/metagetta/specials_test.clj
+++ b/modules/metagetta/test/cljdoc_analyzer/metagetta/specials_test.clj
@@ -1,0 +1,25 @@
+(ns cljdoc-analyzer.metagetta.specials-test
+  "Test various special cases, one at a time"
+  (:require [clojure.test :as t]
+            [cljdoc-analyzer.metagetta.main :as main]))
+
+(defn- analyze-special-source
+  "Analyze the given namespace from `test-sources-special`.
+  Intended for individual tests of special cases."
+  [opts namespace]
+  (main/get-metadata (merge opts {:root-path "test-sources-special"
+                                  :namespaces [namespace]})))
+
+(t/deftest analyze-unknown-tagged-literal-test
+  (let [ns 'metagetta-test-special.unknown-tagged-literal
+        actual (analyze-special-source
+                 {:languages #{"clj" "cljs"}} ns)
+        expected-ns (list
+                      {:name    ns
+                       :publics [{:file "metagetta_test_special/unknown_tagged_literal.cljc"
+                                  :line 4
+                                  :name 'some-data
+                                  :type :var}]})
+        expected {"clj" expected-ns
+                  "cljs" expected-ns}]
+    (t/is (= expected actual))))


### PR DESCRIPTION
for #32

NOTE: I added a separate test source dir because adding it
to the existing one made most of the other tests fail as well,
which is an unfortunate coupling. The new test-sources-special
is intended for testing 1 ns at a time so adding a new ns and test
won't break existing ones.
