### PR TITLE
Fix #32: unknown tagged literals -> valid code

### DIFF
--- a/modules/metagetta/src/cljdoc_analyzer/metagetta/utils.clj
+++ b/modules/metagetta/src/cljdoc_analyzer/metagetta/utils.clj
@@ -139,4 +139,5 @@
 
     (fn failsafe-data-reader-fn [tag value]
       (warn-unknown-tagged-literal-once tag)
-      (tagged-literal tag value))))
+      ;(tagged-literal tag value) ; <-- OK for reading but breaks the Clojure Compiler's `emitValue` unless we define print-dup
+      [:cljdoc/unknown-tagged-literal (name tag) value])))


### PR DESCRIPTION
It turns out we cannot return `(clojure.core/tagged-literal ...)` instead of an unknown t.l., because Clojure Compiler's `emitValue` would fail on that. We need to return something that can be emitted and is a valid piece of code.

With this fix, I was able to analyze Fulcro without any error.