### PR TITLE
Delete clj-kondo.exports/ before analyzing jars

### DIFF
--- a/src/cljdoc_analyzer/runner.clj
+++ b/src/cljdoc_analyzer/runner.clj
@@ -48,6 +48,12 @@
   (when (.exists (io/file unpacked-jar-dir "public"))
     (log/info "Deleting public/ dir")
     (file/delete-directory! (io/file unpacked-jar-dir "public")))
+  ;; Delete the clj-kondo exports directory, which includes clj files
+  ;; with namespaces that don't match their directory location.
+  ;; This fixes the issue https://github.com/cljdoc/cljdoc/issues/455
+  (when (.exists (io/file unpacked-jar-dir "clj-kondo.exports"))
+    (log/info "Deleting clj-kondo.exports/ dir")
+    (file/delete-directory! (io/file unpacked-jar-dir "clj-kondo.exports")))
   ;; Delete .class files that have a corresponding .clj or .cljc file
   ;; to circle around https://dev.clojure.org/jira/browse/CLJ-130
   ;; This only affects Jars with AOT compiled namespaces where the


### PR DESCRIPTION
This is the actual code change that needs to happen as a part of this fix, but since this is my first time contributing and I've never used kaocha before, I'm not super familiar with how the tests are laid out. I'm going to try and figure it out on my own and get tests in for this, but if there are any suggestions for where to look that'd be very helpful.

Before this can be merged:
 - ~~[ ] Add/update tests~~

Fixes cljdoc/cljdoc#455