### PR TITLE
Choose your platform

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -229,8 +229,8 @@ The edn output is a map of:
 * `:artifact-id` project artifact-id
 * `:version` project version
 * `:analysis` analysis for languages which can consist of a map with none, one or both of:
-** `clj` list of namespaces (see below)
-** `cljs` list of namespaces (see below)
+** `"clj"` list of namespaces (see below)
+** `"cljs"` list of namespaces (see below)
 * `:pom-str` slurp of maven pom file
 
 list of namespaces is a list of maps of:

--- a/src/cljdoc_analyzer/cljdoc_main.clj
+++ b/src/cljdoc_analyzer/cljdoc_main.clj
@@ -8,13 +8,14 @@
 
 (defn -main
   [edn-arg]
-  (let [{:keys [project version jarpath pompath extra-repos] :as args} (edn/read-string edn-arg)
+  (let [{:keys [project version jarpath pompath extra-repos languages] :as args} (edn/read-string edn-arg)
         _  (log/info (str "args:\n" (with-out-str (pp/pprint args))))
         {:keys [analysis-status]} (runner/analyze! {:project project
                                                     :version version
                                                     :jarpath jarpath
                                                     :pompath pompath
                                                     :extra-repos extra-repos
+                                                    :languages languages
                                                     :namespaces :all
                                                     :exclude-with [:no-doc :skip-wiki]
                                                     :output-filename (analysis/result-path project version)})]

--- a/src/cljdoc_analyzer/runner.clj
+++ b/src/cljdoc_analyzer/runner.clj
@@ -169,7 +169,7 @@
 
 (defn- get-metadata*
   "Return metadata for project"
-  [{:keys [project version jarpath pompath default-repos extra-repos overrides] :as opts}]
+  [{:keys [project version jarpath pompath default-repos extra-repos overrides languages] :as opts}]
   {:pre [(seq project) (seq version) (seq jarpath) (seq pompath)]}
   (let [work-dir (-> {:prefix (str "cljdoc-" (string/escape project {\/ \-}) "-" version)}
                      fs/create-temp-dir
@@ -194,7 +194,7 @@
              :version version
              :analysis (launch-metagetta (assoc opts
                                                 :src-dir (.getPath jar-contents-dir)
-                                                :languages (or (:languages overrides) :auto-detect)
+                                                :languages (or (:languages overrides) languages :auto-detect)
                                                 :namespaces (or (:namespaces overrides) :all)
                                                 :classpath classpath))
              :pom-str pom-str}
@@ -209,6 +209,7 @@
   - `:jarpath` - path to jar file
   - `:pompath` - path to pom file
   - `:extra-repos` - optional map of additional maven repos.
+  - `:languages` - languages to analyze
 
   To serialize/deserialize result see [[cljdoc-analyzer.analysis-edn]]."
   [{:keys [project] :as opts}]
@@ -228,6 +229,7 @@
   - `:jarpath` - path to jar file
   - `:pompath` - path to pom file
   - `:extra-repos` - optional additional extra maven repositories in map format: `{repo-id-here {:url \"http://repo.url.here\"}}`
+  - `:languages` - languages to analyze
   - `:output-filename` - where to write output
 
   This function wraps [[get-metadata]]. It does some logging and serializes result appropriately. If you want to do


### PR DESCRIPTION
Cljdoc-analyzer now accepts languages as an input.

For edn and tools command line :languages is now recognized.
Its value can be:
- :auto-detect (default and only previous behavior)
- a collection of one or both of: "clj" "cljs"

The conventional user command line now accepts --language which can specify clj
or cljs. Repeat the option for both. Omit the option for auto detect.

In support of #468