### PR TITLE
Exclude MrAnderson inlined namespaces from docs

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,7 +10,8 @@
 
 == Unreleased
 
-*
+* Exclude MrAnderson inlined namespaces
+https://github.com/cljdoc/cljdoc-analyzer/issues/4[#4]
 
 == v1.0.702
 

--- a/README.adoc
+++ b/README.adoc
@@ -75,6 +75,9 @@ For example:
 The Clojure core team still uses https://tomfaulhaber.github.io/autodoc[autodoc] to generate their API docs.
 Autodoc's `:skip-wiki` metadata is equivalent to `:no-doc`.
 
+The default metadata that https://github.com/benedekfazekas/mranderson[MrAnderson] adds to inlined namespaces is `:mranderson/inlined`.
+We see this as equivalent to `:no-doc` and `:skip-wiki`.
+
 ==== :added
 
 To denote the library version the var was added in, use the `:added` metadata key:
@@ -158,6 +161,7 @@ clojure -M -m cljdoc-analyzer.main analyze \
   --output-filename "io-aviso-pretty-0.1.29.edn" \
   --exclude-with :no-doc \
   --exclude-with :skip-wiki \
+  --exclude-with :mranderson/inlined \
   --extra-repo "clojars https://repo.clojars.org/" \
   --extra-repo "central http://central.maven.org/maven2/"
 ----
@@ -264,6 +268,7 @@ special metadata tags when present are included on namespaces and/or publics:
 * `:deprecated` version an element was deprecated
 * `:no-doc` author requests that this item be excluded from docs
 * `:skip-wiki` autodoc's equivalent to `:no-doc`
+* `:mranderson/inlined` metadata that mranderson places on inlined namespaces
 
 [#internal-workings]
 == Internal Workings

--- a/modules/metagetta/src/cljdoc_analyzer/metagetta/clojure.clj
+++ b/modules/metagetta/src/cljdoc_analyzer/metagetta/clojure.clj
@@ -67,7 +67,7 @@
     (-> (meta var)
         (select-keys [:name :file :line :arglists :doc :dynamic
                       :added :deprecated
-                      :no-doc :skip-wiki])
+                      :no-doc :skip-wiki :mranderson/inlined])
         (utils/update-some :doc utils/correct-indent)
         (utils/update-some :file normalize)
         (utils/assoc-some  :type (var-type var)
@@ -92,7 +92,7 @@
       (require namespace))
     (-> (find-ns namespace)
         (meta)
-        (select-keys [:doc :author :deprecated :added :no-doc :skip-wiki])
+        (select-keys [:doc :author :deprecated :added :no-doc :skip-wiki :mranderson/inlined])
         (assoc :name namespace)
         (assoc :publics (read-publics source-path namespace))
         (utils/update-some :doc utils/correct-indent)
@@ -135,6 +135,7 @@
     :author    - if the metadata is there, we return it
     :no-doc    - request for namespace not to be documented
     :skip-wiki - legacy synonym for :no-doc
+    :mranderson/inlined - default metadata for mranderson inline namespace
     :publics
       :name       - the name of a public function, macro, or value
       :file       - the file the var was declared in
@@ -145,7 +146,8 @@
       :added      - the library version the var was added in
       :deprecated - the library version the var was deprecated in
       :no-doc     - request for var not to be documented
-      :skip-wiki    - legacy synonym for :no-doc"
+      :skip-wiki    - legacy synonym for :no-doc
+      :mranderson/inlined - default meta for mranderson inlined"
 
   ([path] (read-namespaces path {}))
   ([path {:keys [exception-handler exclude-with]

--- a/modules/metagetta/src/cljdoc_analyzer/metagetta/clojurescript.clj
+++ b/modules/metagetta/src/cljdoc_analyzer/metagetta/clojurescript.clj
@@ -70,7 +70,7 @@
     (-> var
         (select-keys [:name :file :line :arglists :doc :dynamic
                       :added :deprecated
-                      :no-doc :skip-wiki])
+                      :no-doc :skip-wiki :mranderson/inlined])
         (utils/update-some :name (comp symbol name))
         (utils/update-some :arglists remove-quote)
         (utils/update-some :doc utils/correct-indent)
@@ -152,7 +152,7 @@
              (-> ns
                  (select-keys [:name :doc])
                  (utils/update-some :doc utils/correct-indent)
-                 (merge (-> ns-name meta (select-keys [:no-doc :skip-wiki :author :deprecated :added])))
+                 (merge (-> ns-name meta (select-keys [:no-doc :skip-wiki :mranderson/inlined :author :deprecated :added])))
                  (utils/remove-empties)
                  (assoc :publics (read-publics state ns-name source-path file)))})
           (println "Dropping" file "because" ns-name "was not present in state. Is it missing an (ns) declaration?")))
@@ -191,6 +191,7 @@
     :author    - if the metadata is there, we return it
     :no-doc    - request for namespace not to be documented
     :skip-wiki - legacy synonym for :no-doc
+    :mranderson/inlined - default metadata for mranderson inline namespace
     :publics
       :name       - the name of a public function, macro, or value
       :file       - the file the var was declared in
@@ -201,7 +202,8 @@
       :added      - the library version the var was added in
       :deprecated - the library version the var was deprecated in
       :no-doc     - request for var not to be documented
-      :skip-wiki    - legacy synonym for :no-doc"
+      :skip-wiki    - legacy synonym for :no-doc
+      :mranderson/inlined - default meta for mranderson inlined"
   ([path] (read-namespaces path {}))
   ([path {:keys [exception-handler exclude-with]
            :or {exception-handler (partial utils/default-exception-handler "ClojureScript")}}]

--- a/modules/metagetta/src/cljdoc_analyzer/metagetta/main.clj
+++ b/modules/metagetta/src/cljdoc_analyzer/metagetta/main.clj
@@ -160,7 +160,7 @@
     when namespace is a symbol, match is absolute
     when namespace is a string, match is by regular expression
   - `:output-filename` - on success, edn is serialized to this file with special encoding for regexes.
-  - `:exclude-with` - optional - exclude ns and publics with any key in vector - ex [:no-doc :skip-wiki]
+  - `:exclude-with` - optional - exclude ns and publics with any key in vector - ex [:no-doc :skip-wiki :mranderson/inlined]
 
   Launching a separate process for analysis is necessary to limit the dependencies to the minimum required.
 

--- a/modules/metagetta/test-sources/metagetta_test/test_ns1/mranderson_inlined_ns.cljc
+++ b/modules/metagetta/test-sources/metagetta_test/test_ns1/mranderson_inlined_ns.cljc
@@ -1,0 +1,6 @@
+;;
+;; Note: this file is used in tests that rely on line numbers
+;;
+(ns ^:mranderson/inlined metagetta-test.test-ns1.mranderson-inlined-ns)
+
+(defn an-inlined-var[a] a)

--- a/modules/metagetta/test/cljdoc_analyzer/metagetta/main_test.clj
+++ b/modules/metagetta/test/cljdoc_analyzer/metagetta/main_test.clj
@@ -71,19 +71,29 @@
                      :arglists '([a & xs])
                      :type :macro
                      :file "metagetta_test/test_ns1/macro.cljc"
-                     :line 17}]}
-         {:name 'metagetta-test.test-ns1.multiarity
-          :publics [{:name 'multiarity
-                     :arglists '([] [a] [a b] [a b c d])
-                     :type :var
-                     :doc "Multiarity comment\n"
-                       :file "metagetta_test/test_ns1/multiarity.cljc"
-                     :line 7}]}
-         {:name 'metagetta-test.test-ns1.multimethod
-          :publics [{:name 'start
-                     :type :multimethod
-                     :file "metagetta_test/test_ns1/multimethod.cljc"
-                     :line 6}]})
+                     :line 17}]})
+   (when (not (in? opts :mranderson/inlined))
+     (list
+       {:name 'metagetta-test.test-ns1.mranderson-inlined-ns,
+        :publics [{:arglists '([a]),
+                   :file "metagetta_test/test_ns1/mranderson_inlined_ns.cljc",
+                   :line 6
+                   :name 'an-inlined-var
+                   :type :var}]
+        :mranderson/inlined true}))
+   (list
+     {:name 'metagetta-test.test-ns1.multiarity
+      :publics [{:name 'multiarity
+                 :arglists '([] [a] [a b] [a b c d])
+                 :type :var
+                 :doc "Multiarity comment\n"
+                 :file "metagetta_test/test_ns1/multiarity.cljc"
+                 :line 7}]}
+     {:name 'metagetta-test.test-ns1.multimethod
+      :publics [{:name 'start
+                 :type :multimethod
+                 :file "metagetta_test/test_ns1/multimethod.cljc"
+                 :line 6}]})
    (when (not (in? opts :no-doc))
      (list
        {:doc "This namespace will be marked with no-doc at load-time\n"
@@ -249,9 +259,9 @@
   ;; requires special setup, see test task in bb.edn
   (let [actual (analyze-sources {:root-path "target/no-doc-sources-test"
                                  :languages #{"clj" "cljs"}
-                                 :exclude-with [:no-doc :skip-wiki]})
-        expected {"clj" (expected-result :clj :no-doc :skip-wiki)
-                  "cljs" (expected-result :cljs :no-doc :skip-wiki)}]
+                                 :exclude-with [:no-doc :skip-wiki :mranderson/inlined]})
+        expected {"clj" (expected-result :clj :no-doc :skip-wiki :mranderson/inlined)
+                  "cljs" (expected-result :cljs :no-doc :skip-wiki :mranderson/inlined)}]
     (t/is (= expected actual))))
 
 (t/deftest analyze-select-namespace-no-matches-test

--- a/src/cljdoc_analyzer/cljdoc_main.clj
+++ b/src/cljdoc_analyzer/cljdoc_main.clj
@@ -17,7 +17,7 @@
                                                     :extra-repos extra-repos
                                                     :languages languages
                                                     :namespaces :all
-                                                    :exclude-with [:no-doc :skip-wiki]
+                                                    :exclude-with [:no-doc :skip-wiki :mranderson/inlined]
                                                     :output-filename (analysis/result-path project version)})]
     (shutdown-agents)
     (System/exit (if (= :success analysis-status) 0 1))))

--- a/src/cljdoc_analyzer/deps_tool.clj
+++ b/src/cljdoc_analyzer/deps_tool.clj
@@ -35,7 +35,7 @@
                                        :pompath (or pompath pom)
                                        :extra-repos extra-repos
                                        :namespaces :all
-                                       :exclude-with [:no-doc :skip-wiki]
+                                       :exclude-with [:no-doc :skip-wiki :mranderson/inlined]
                                        :output-filename (or output-filename
                                                           (str "output-" project "-" version ".edn"))}))]
     (shutdown-agents)

--- a/src/cljdoc_analyzer/main.clj
+++ b/src/cljdoc_analyzer/main.clj
@@ -20,7 +20,7 @@
         languages (when (seq language) (into #{} language))
         {:keys [jar pom]} (deps/resolve-dep (symbol project) version (:repos config) extra-repos)]
     (runner/analyze! (-> (merge
-                          {:exclude-with [:no-doc :skip-wiki]}
+                          {:exclude-with [:no-doc :skip-wiki :mranderson/inlined]}
                           (select-keys args [:project :version :exclude-with :output-filename]))
                          (assoc :jarpath jar :pompath pom :extra-repos extra-repos :languages languages)))))
 

--- a/test/integration/cljdoc_analyzer/main_shell_test.clj
+++ b/test/integration/cljdoc_analyzer/main_shell_test.clj
@@ -21,6 +21,7 @@
                                                   "--version" version
                                                   "--exclude-with" ":no-doc"
                                                   "--exclude-with" ":skip-wiki"
+                                                  "--exclude-with" ":mranderson/inlined"
                                                   "--output-filename" edn-out-filename))))
 
 ;; main testing is done in cljdoc-main-test, this is a sanity run that this main path works as well.


### PR DESCRIPTION
Any namespace with metadata :mranderson/inlined is now also treated like one with :no-doc or :skip-wiki metadata and excluded.

Also excluding vars with this meta, although MrAnderson does not currently add this metadata at the var level.

Closes #4