### PR TITLE
Bump default versions of Clojure, ClojureScript

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,7 +10,7 @@
 
 == Unreleased
 
-*
+* Bump default versions of Clojure, ClojureScript used for analysis https://github.com/cljdoc/cljdoc-analyzer/issues/60[#60]
 
 == v1.0.705
 

--- a/src/cljdoc_analyzer/deps.clj
+++ b/src/cljdoc_analyzer/deps.clj
@@ -21,8 +21,8 @@
             min-versions)))
 
 (defn- ensure-required-deps [deps-map]
-  (merge {'org.clojure/clojure {:mvn/version "1.10.1"}
-          'org.clojure/clojurescript {:mvn/version "1.10.773"}
+  (merge {'org.clojure/clojure {:mvn/version "1.11.1"}
+          'org.clojure/clojurescript {:mvn/version "1.11.60"}
           ;; many ring libraries implicitly depend on this and getting all
           ;; downstream libraries to properly declare it as a "provided"
           ;; dependency would be a major effort. since it's all java it also


### PR DESCRIPTION
When a lib does not specify a default version of Clojure and/or ClojureScript, cljdoc specifies default versions for analysis.

Bump the defaults to current releases so that libs like malli that use Clojure 1.11 features like :as-alias will successfully analyze.

Closes #60