### PR TITLE
ci: match builder circleci docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,9 @@
-# Clojure CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-clojure/ for more details
-#
-version: 2
+version: 2.1
+
 jobs:
   build:
     docker:
-      - image: circleci/clojure:openjdk-11-tools-deps-1.10.3.1058-buster
-
-    working_directory: ~/repo
+      - image: clojure:temurin-17-tools-deps
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run:
           name: Install babashka
           command: |
-            sudo bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
+            bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
 
       - run:
           name: Dump tools versions


### PR DESCRIPTION
The builder project runs cljdoc doc builds as jobs on CircleCI.

Builder now uses the clojure:temurin-17-tools-deps docker image.

Makes sense to match that docker image when running our tests here.