### PR TITLE
maint: bump deps

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,7 +10,7 @@
 
 == Unreleased
 
-*
+* Bump deps
 
 == v1.0.718
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,27 +1,29 @@
 {:paths ["src" "resources" "modules"]
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        org.clojure/tools.deps {:mvn/version "0.16.1264"}
+        org.clojure/tools.deps {:mvn/version "0.16.1281"}
         org.clojure/tools.logging {:mvn/version "1.2.4"}
         ch.qos.logback/logback-classic {:mvn/version "1.4.5"}
         version-clj/version-clj {:mvn/version "2.0.2"}
         cli-matic/cli-matic {:mvn/version "0.5.4"}
-        babashka/fs {:mvn/version "0.2.12"}
+        babashka/fs {:mvn/version "0.2.16"}
         ;; cljoc and cljdoc-analyzer should reference same version of cljdoc-shared
         cljdoc/cljdoc-shared {:git/url "https://github.com/cljdoc/cljdoc-shared.git"
                               :git/sha "53c113e375df94d50cf96c6f2c1b3842dc0e9b35"}}
  :tools/usage {:ns-default cljdoc-analyzer.deps-tool}
  :aliases {:test
            {:extra-paths ["test/integration" "test-resources"]
-            :extra-deps {lambdaisland/kaocha {:mvn/version "1.72.1136"}
+            :extra-deps {lambdaisland/kaocha {:mvn/version "1.77.1236"}
                          lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}}
             :main-opts ["-m" "kaocha.runner"]}
 
            :clj-kondo
-           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2023.01.12"}}
+           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2023.02.17"}}
             :main-opts ["-m" "clj-kondo.main"]}
 
            :outdated
-           {:replace-deps {com.github.liquidz/antq {:mvn/version "2.2.970"}
+           {:replace-deps {com.github.liquidz/antq {:mvn/version "2.2.992"}
                            org.slf4j/slf4j-simple {:mvn/version "2.0.6"} ;; to rid ourselves of logger warnings
                            }
-            :main-opts ["-m" "antq.core"]}}}
+            :main-opts ["-m" "antq.core"
+                        "--exclude=org.clojure/tools.namespace@1.4.1" ;; https://clojure.atlassian.net/browse/TNS-59
+                        ]}}}

--- a/modules/metagetta/deps.edn
+++ b/modules/metagetta/deps.edn
@@ -1,10 +1,10 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        org.clojure/tools.namespace {:mvn/version "1.3.0"}
+        org.clojure/tools.namespace {:mvn/version "1.4.0"}
         org.clojure/clojurescript {:mvn/version "1.11.60"}}
  :aliases {:test-base
            {:extra-paths ["test"]
-            :extra-deps {lambdaisland/kaocha {:mvn/version "1.72.1136"}
+            :extra-deps {lambdaisland/kaocha {:mvn/version "1.77.1236"}
                          lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}}}
 
            :test-sources


### PR DESCRIPTION
We'll avoid org.clojure/tools.namespace 1.4.1 for now: https://clojure.atlassian.net/browse/TNS-55