### PR TITLE
dev: add eastwood linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
     steps:
       - checkout
 
-
       - restore_cache:
           keys:
             - v1-dependencies-{{checksum "deps.edn"}}-{{ checksum "modules/metagetta/deps.edn" }}
@@ -39,9 +38,14 @@ jobs:
             clojure -P -M:test
 
       - run:
-          name: Lint
+          name: Lint clj-kondo
           command: |
             bb lint
+
+      - run:
+          name: Lint eastwood
+          command: |
+            bb eastwood
 
       - run:
           name: Test

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,8 @@
 == Unreleased
 
 * Bump deps
+* Internal dev-facing stuff:
+** Add eastwood linting https://github.com/cljdoc/cljdoc-analyzer/issues/67[#67]
 
 == v1.0.718
 

--- a/bb.edn
+++ b/bb.edn
@@ -31,6 +31,10 @@
                       (= 3 exit) (status/die exit "clj-kondo found one or more lint warnings")
                       (> exit 0) (status/die exit "clj-kondo returned unexpected exit code"))))}
 
+         eastwood
+         {:doc "Lint source code using eastwood"
+          :task (clojure "-M:eastwood")}
+
          test-metagetta
          {:doc "metagetta unit tests"
           :task (shell {:dir "modules/metagetta"}

--- a/deps.edn
+++ b/deps.edn
@@ -20,6 +20,12 @@
            {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2023.02.17"}}
             :main-opts ["-m" "clj-kondo.main"]}
 
+           :eastwood
+           {:extra-paths ["test/integration"]
+            :extra-deps {jonase/eastwood {:mvn/version "1.3.0"}}
+            :main-opts ["-m" "eastwood.lint" {:source-paths ["src"]
+                                              :test-paths ["test/integration"]}]}
+
            :outdated
            {:replace-deps {com.github.liquidz/antq {:mvn/version "2.2.992"}
                            org.slf4j/slf4j-simple {:mvn/version "2.0.6"} ;; to rid ourselves of logger warnings

--- a/src/cljdoc_analyzer/deps.clj
+++ b/src/cljdoc_analyzer/deps.clj
@@ -35,10 +35,10 @@
   [target-dir]
   {'cljdoc-analyzer/metagetta
    {:local/root (if-let [metagetta-jar-resource (io/resource "metagetta.jar")]
-                  (let [target-jar (str (io/file target-dir "metagetta.jar"))]
+                  (let [target-jar (str (fs/file target-dir "metagetta.jar"))]
                     (fs/copy-tree metagetta-jar-resource target-jar)
                     target-jar)
-                  (clojure.java.io/resource "metagetta"))}})
+                  (io/resource "metagetta"))}})
 
 (defn- extra-pom-deps
   "Some projects require additional depenencies that have either been specified with
@@ -55,7 +55,7 @@
        ;; Remains to be seen if this causes any issues
        ;; http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management
        (remove #(nil? (:version %)))
-       (remove #(.startsWith (:artifact-id %) "boot-"))
+       (remove #(string/starts-with? (:artifact-id %) "boot-"))
        ;; Ensure that tools.reader version is used as specified by CLJS
        (remove #(and (= (:group-id %) "org.clojure")
                      (= (:artifact-id %) "tools.reader")))

--- a/src/cljdoc_analyzer/file.clj
+++ b/src/cljdoc_analyzer/file.clj
@@ -1,7 +1,5 @@
 (ns ^:no-doc cljdoc-analyzer.file
-  (:require [clojure.java.io :as io]
-            [clojure.string :as string])
-  (:import (java.nio.file Files)))
+  (:require [clojure.java.io :as io]))
 
 (defn copy [source target]
   (io/make-parents target)
@@ -9,9 +7,3 @@
               out (io/output-stream target)]
     (io/copy in out)))
 
-;; move to babashka fs when available: https://github.com/babashka/fs/issues/31
-(defn system-temp-file [prefix suffix]
-  (.toFile (Files/createTempFile
-            (clojure.string/replace prefix #"/" "-")
-            suffix
-            (into-array java.nio.file.attribute.FileAttribute []))))

--- a/test/integration/cljdoc_analyzer/main_shell_test.clj
+++ b/test/integration/cljdoc_analyzer/main_shell_test.clj
@@ -1,19 +1,16 @@
 (ns ^:integration cljdoc-analyzer.main-shell-test
   "These tests do not represent the way cljdoc calls cljdoc-analyzer.
    They are here to ensure our command-line friendly adhoc interface works."
-  (:require [clojure.test :as t]
+  (:require [babashka.fs :as fs]
+            [clojure.test :as t]
             [clojure.java.shell :as shell]
             [cljdoc-analyzer.test-helper :as test-helper]))
 
-(defn- temp-edn-filename []
-  (str
-   (doto (java.io.File/createTempFile "cljdoc-analysis-edn" ".edn")
-     (.deleteOnExit)
-     (.getAbsolutePath))))
-
 (defn- run-analysis [project version]
   (println "Analyzing" project version)
-  (let [edn-out-filename (temp-edn-filename)]
+  (let [edn-out-filename (str (fs/create-temp-file {:prefix "cljdoc-analysis-edn"
+                                                    :suffix ".edn"}))]
+    (fs/delete-on-exit edn-out-filename)
     (test-helper/verify-analysis-result project version edn-out-filename
                                         (shell/sh "clojure" "-M" "--report" "stderr" "-m" "cljdoc-analyzer.main"
                                                   "analyze"

--- a/test/integration/cljdoc_analyzer/test_helper.clj
+++ b/test/integration/cljdoc_analyzer/test_helper.clj
@@ -1,5 +1,6 @@
 (ns cljdoc-analyzer.test-helper
-  (:require [clojure.test :as t]
+  (:require [babashka.fs]
+            [clojure.test :as t]
             [clojure.java.io :as io]
             [clojure.string :as string]
             [cljdoc-shared.analysis-edn :as analysis-edn]))
@@ -33,7 +34,7 @@
                        :version version
                        :path (edn-filename "expected-edn" project version)})))
     (let [expected-analysis (analysis-edn/read expected-f)
-          actual-analysis (analysis-edn/read edn-out-filename)]
+          actual-analysis (analysis-edn/read (str edn-out-filename))]
       (cond
         ;; For specter package, filter the "com.rpl.specter.impl" namespace
         (and (= project "com.rpl/specter")


### PR DESCRIPTION
Got rid of reflection warnings and also:
- moved to babashka/fs abstractions where I noticed we could use them
- moved to clojure.string abstractions

Chose not to eastwood lint metagetta at this time.

Closes #67