### PR TITLE
Initial artifact resolve no longer resolves deps

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,7 +10,8 @@
 
 == Unreleased
 
-*
+* Artifacts that reference non-default maven repos now analyze properly for user-facing cmd line
+https://github.com/cljdoc/cljdoc-analyzer/issues/78[#78]
 
 == v1.0.731
 

--- a/src/cljdoc_analyzer/deps_tool.clj
+++ b/src/cljdoc_analyzer/deps_tool.clj
@@ -17,7 +17,7 @@
 
 (defn maybe-download [{:keys [download extra-repos project version]}]
   (when download
-    (deps/resolve-dep
+    (deps/resolve-artifact
       (symbol project) version
       (:repos (config/load))
       (extra-repo-arg-to-option extra-repos))))

--- a/src/cljdoc_analyzer/main.clj
+++ b/src/cljdoc_analyzer/main.clj
@@ -18,7 +18,7 @@
   (let [config (config/load)
         extra-repos (extra-repo-arg-to-option extra-repo)
         languages (when (seq language) (into #{} language))
-        {:keys [jar pom]} (deps/resolve-dep (symbol project) version (:repos config) extra-repos)]
+        {:keys [jar pom]} (deps/resolve-artifact (symbol project) version (:repos config) extra-repos)]
     (runner/analyze! (-> (merge
                           {:exclude-with [:no-doc :skip-wiki :mranderson/inlined]}
                           (select-keys args [:project :version :exclude-with :output-filename]))

--- a/test/integration/cljdoc_analyzer/main_shell_test.clj
+++ b/test/integration/cljdoc_analyzer/main_shell_test.clj
@@ -3,6 +3,7 @@
    They are here to ensure our command-line friendly adhoc interface works."
   (:require [babashka.fs :as fs]
             [clojure.test :as t]
+            [clojure.tools.deps :as tdeps]
             [clojure.java.shell :as shell]
             [cljdoc-analyzer.test-helper :as test-helper]))
 
@@ -22,5 +23,13 @@
                                                   "--output-filename" edn-out-filename))))
 
 ;; main testing is done in cljdoc-main-test, this is a sanity run that this main path works as well.
-(t/deftest bidi
-  (run-analysis "bidi" "2.1.3"))
+(t/deftest clj-branca
+  ;; force re-download of artifact to local maven repo by deleting it first
+  (let [project 'miikka/clj-branca
+        version "0.1.0"
+        {:keys [base path]} (tdeps/lib-location project {:mvn/version version} {})
+        m2-repo-dir (fs/file base path)]
+    (when (fs/exists? m2-repo-dir)
+      (println "deleting" (str m2-repo-dir))
+      (fs/delete-tree m2-repo-dir))
+    (run-analysis (str project) version)))


### PR DESCRIPTION
For the user facing command lines, we now download the artifact and pom only and make no attempt to resolve its dependencies. Attempting to resolve dependencies would fail for artifacts that reference extra non-default maven repositories.

Full dependency resolution occurs later during analysis and will automatically include any extra maven repositories specified by the analyzed artifact.

Switch integration user cmd line integration test to use miikka clj-branca to exercise our fix. It specifies and relies on jcenter maven repo.

We continue to use clojure/tools.deps internals.
But that slope was already slipped down.

Closes #78