### PR TITLE
maint: bump deps, add lint options

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,1 +1,6 @@
-{:config-paths ^:replace []}
+{:config-paths ^:replace []
+ :linters
+ {:redundant-str-cal {:level :warning}
+  :redundant-fn-wrapper {:level :warning}
+  :aliased-namespace-symbol {:level :warning}
+  :unsorted-required-namespaces {:level :warning}}}

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,7 +10,7 @@
 
 == Unreleased
 
-*
+* Bump deps
 
 == v1.0.792
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,11 +1,11 @@
 {:paths ["src" "resources" "modules"]
- :deps {org.clojure/clojure {:mvn/version "1.11.2"}
-        org.clojure/tools.deps {:mvn/version "0.19.1417"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.3"}
+        org.clojure/tools.deps {:mvn/version "0.19.1432"}
         org.clojure/tools.logging {:mvn/version "1.3.0"}
         ch.qos.logback/logback-classic {:mvn/version "1.5.6"}
         version-clj/version-clj {:mvn/version "2.0.2"}
         cli-matic/cli-matic {:mvn/version "0.5.4"}
-        babashka/fs {:mvn/version "0.5.20"}
+        babashka/fs {:mvn/version "0.5.21"}
         org.ow2.asm/asm {:mvn/version "9.7"}
         ;; cljoc and cljdoc-analyzer should reference same version of cljdoc-shared
         cljdoc/cljdoc-shared {:git/url "https://github.com/cljdoc/cljdoc-shared.git"
@@ -13,12 +13,12 @@
  :tools/usage {:ns-default cljdoc-analyzer.deps-tool}
  :aliases {:test
            {:extra-paths ["test/integration" "test-resources"]
-            :extra-deps {lambdaisland/kaocha {:mvn/version "1.88.1376"}
+            :extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}
                          lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}}
             :main-opts ["-m" "kaocha.runner"]}
 
            :clj-kondo
-           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.03.13"}}
+           {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.05.24"}}
             :main-opts ["-m" "clj-kondo.main"]}
 
            :eastwood
@@ -28,7 +28,7 @@
                                               :test-paths ["test/integration"]}]}
 
            :outdated
-           {:replace-deps {com.github.liquidz/antq {:mvn/version "2.8.1194"}
+           {:replace-deps {com.github.liquidz/antq {:mvn/version "2.8.1201"}
                            org.slf4j/slf4j-simple {:mvn/version "2.0.13"} ;; to rid ourselves of logger warnings
                            }
             :main-opts ["-m" "antq.core"

--- a/modules/metagetta/deps.edn
+++ b/modules/metagetta/deps.edn
@@ -1,9 +1,9 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.11.2"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.3"}
         org.clojure/clojurescript {:mvn/version "1.11.132"}}
  :aliases {:test-base
            {:extra-paths ["test"]
-            :extra-deps {lambdaisland/kaocha {:mvn/version "1.88.1376"}
+            :extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}
                          lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}}}
 
            :test-sources

--- a/modules/metagetta/src/cljdoc_analyzer/metagetta/clojure.clj
+++ b/modules/metagetta/src/cljdoc_analyzer/metagetta/clojure.clj
@@ -1,10 +1,12 @@
 (ns ^:no-doc cljdoc-analyzer.metagetta.clojure
   "Read raw documentation information from Clojure source directory."
-  (:import java.util.jar.JarFile
-           java.io.FileNotFoundException)
-  (:require [clojure.java.io :as io]
-            [cljdoc-analyzer.metagetta.inlined.toolsnamespace.v1v4v0.clojure.tools.namespace.find :as ns-find]
-            [cljdoc-analyzer.metagetta.utils :as utils]))
+  (:require
+   [cljdoc-analyzer.metagetta.inlined.toolsnamespace.v1v4v0.clojure.tools.namespace.find :as ns-find]
+   [cljdoc-analyzer.metagetta.utils :as utils]
+   [clojure.java.io :as io])
+  (:import
+   java.io.FileNotFoundException
+   java.util.jar.JarFile))
 
 (defn try-require [namespace]
   (try

--- a/modules/metagetta/src/cljdoc_analyzer/metagetta/clojurescript.clj
+++ b/modules/metagetta/src/cljdoc_analyzer/metagetta/clojurescript.clj
@@ -1,17 +1,18 @@
 (ns ^:no-doc cljdoc-analyzer.metagetta.clojurescript
   "Read raw documentation information from ClojureScript source directory."
-  (:require [clojure.java.io :as io]
-            [clojure.string :as str]
-            [cljs.analyzer.api :as ana]
-            [cljs.closure]
-            [cljs.compiler.api :as comp]
-            [cljs.env]
-            [cljs.util :as cljs-util]
-            [clojure.set]
-            [cljdoc-analyzer.metagetta.utils :as utils]
-            [cljdoc-analyzer.metagetta.inlined.javaclasspath.v1v0v0.clojure.java.classpath :as cp]
-            [cljdoc-analyzer.metagetta.inlined.toolsnamespace.v1v4v0.clojure.tools.namespace.find :as ns-find]
-            [cljdoc-analyzer.metagetta.inlined.toolsnamespace.v1v4v0.clojure.tools.namespace.parse :as ns-parse]))
+  (:require
+   [cljdoc-analyzer.metagetta.inlined.javaclasspath.v1v0v0.clojure.java.classpath :as cp]
+   [cljdoc-analyzer.metagetta.inlined.toolsnamespace.v1v4v0.clojure.tools.namespace.find :as ns-find]
+   [cljdoc-analyzer.metagetta.inlined.toolsnamespace.v1v4v0.clojure.tools.namespace.parse :as ns-parse]
+   [cljdoc-analyzer.metagetta.utils :as utils]
+   [cljs.analyzer.api :as ana]
+   [cljs.closure]
+   [cljs.compiler.api :as comp]
+   [cljs.env]
+   [cljs.util :as cljs-util]
+   [clojure.java.io :as io]
+   [clojure.set]
+   [clojure.string :as str]))
 
 (defn- default-data-reader-fn-var
   "Starting with ClojureScript 1.11.51 tools reader is vendorized to cljs.vendor.clojure.tools.reader"

--- a/modules/metagetta/src/cljdoc_analyzer/metagetta/main.clj
+++ b/modules/metagetta/src/cljdoc_analyzer/metagetta/main.clj
@@ -1,12 +1,13 @@
 (ns ^:no-doc cljdoc-analyzer.metagetta.main
   "Main namespace for generating documentation"
-  (:require [clojure.walk :as walk]
-            [clojure.edn :as edn]
-            [clojure.java.io :as io]
-            [clojure.pprint :as pprint]
-            [clojure.string :as string]
-            [cljdoc-analyzer.metagetta.clojure :as clj]
-            [cljdoc-analyzer.metagetta.utils :as utils]))
+  (:require
+   [cljdoc-analyzer.metagetta.clojure :as clj]
+   [cljdoc-analyzer.metagetta.utils :as utils]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.pprint :as pprint]
+   [clojure.string :as string]
+   [clojure.walk :as walk]))
 
 (defn- namespace-readers [lang]
   (case lang

--- a/modules/metagetta/test/cljdoc_analyzer/metagetta/main_test.clj
+++ b/modules/metagetta/test/cljdoc_analyzer/metagetta/main_test.clj
@@ -1,7 +1,8 @@
 (ns cljdoc-analyzer.metagetta.main-test
   "Load all `test-sources/*` namespaces and test various things about them."
-  (:require [clojure.test :as t]
-            [cljdoc-analyzer.metagetta.main :as main]))
+  (:require
+   [cljdoc-analyzer.metagetta.main :as main]
+   [clojure.test :as t]))
 
 (defn- in? [coll elem]
   (some #(= elem %) coll))

--- a/modules/metagetta/test/cljdoc_analyzer/metagetta/specials_test.clj
+++ b/modules/metagetta/test/cljdoc_analyzer/metagetta/specials_test.clj
@@ -1,7 +1,8 @@
 (ns cljdoc-analyzer.metagetta.specials-test
   "Test various special cases, one at a time"
-  (:require [clojure.test :as t]
-            [cljdoc-analyzer.metagetta.main :as main]))
+  (:require
+   [cljdoc-analyzer.metagetta.main :as main]
+   [clojure.test :as t]))
 
 (defn- analyze-special-source
   "Analyze the given namespace from `test-sources-special`.

--- a/modules/metagetta/test/cljdoc_analyzer/metagetta/utils_test.clj
+++ b/modules/metagetta/test/cljdoc_analyzer/metagetta/utils_test.clj
@@ -1,7 +1,9 @@
 (ns cljdoc-analyzer.metagetta.utils-test
-  (:require [clojure.test :as t]
-            [cljdoc-analyzer.metagetta.utils :as utils])
-  (:import [java.time Duration]) )
+  (:require
+   [cljdoc-analyzer.metagetta.utils :as utils]
+   [clojure.test :as t])
+  (:import
+   [java.time Duration]) )
 
 (t/deftest humanize-duration-test
   (t/is (= "1s" (utils/humanize-duration (Duration/ofMillis 1000))))

--- a/src/cljdoc_analyzer/cljdoc_main.clj
+++ b/src/cljdoc_analyzer/cljdoc_main.clj
@@ -1,10 +1,11 @@
 (ns ^:no-doc cljdoc-analyzer.cljdoc-main
   "Launch cljdoc-analyzer with arguments from edn string"
-  (:require [clojure.pprint :as pp]
-            [clojure.edn :as edn]
-            [clojure.tools.logging :as log]
-            [cljdoc-shared.analysis :as analysis]
-            [cljdoc-analyzer.runner :as runner]))
+  (:require
+   [cljdoc-analyzer.runner :as runner]
+   [cljdoc-shared.analysis :as analysis]
+   [clojure.edn :as edn]
+   [clojure.pprint :as pp]
+   [clojure.tools.logging :as log]))
 
 (defn -main
   [edn-arg]

--- a/src/cljdoc_analyzer/config.clj
+++ b/src/cljdoc_analyzer/config.clj
@@ -1,7 +1,8 @@
 (ns ^:no-doc cljdoc-analyzer.config
   (:refer-clojure :exclude [load])
-  (:require [clojure.java.io :as io]
-            [clojure.edn :as edn]))
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
 
 (defn load[]
   (edn/read-string (slurp (io/resource "config.edn"))))

--- a/src/cljdoc_analyzer/deps.clj
+++ b/src/cljdoc_analyzer/deps.clj
@@ -5,12 +5,12 @@
    [clojure.java.io :as io]
    [clojure.string :as string]
    [clojure.tools.deps :as tdeps]
-   [version-clj.core :as v]
    ;; the following not part of the tools deps public API, will reconsider if this causes us any grief
    [clojure.tools.deps.extensions :as tdeps-ext]
    [clojure.tools.deps.extensions.pom :as tdeps-pom]
    [clojure.tools.deps.util.maven :as tdeps-maven]
-   [clojure.tools.deps.util.session :as tdeps-session])
+   [clojure.tools.deps.util.session :as tdeps-session]
+   [version-clj.core :as v])
   (:import
    [org.apache.maven.model Dependency Model Repository]
    [org.apache.maven.model.building StringModelSource]))
@@ -116,7 +116,7 @@
   "Taken from clojure/tools.deps `clojure.tools.deps.extensions.pom` and modified to support reading from a slurpable-pom."
   ^Model [slurpable-pom config]
   (let [pom-str (slurp slurpable-pom)
-        settings (tdeps-session/retrieve :mvn/settings #(tdeps-maven/get-settings))]
+        settings (tdeps-session/retrieve :mvn/settings tdeps-maven/get-settings)]
     (tdeps-session/retrieve
       {:pom :model :source slurpable-pom}
       #(tdeps-pom/read-model (StringModelSource. pom-str) config settings))))

--- a/src/cljdoc_analyzer/deps_tool.clj
+++ b/src/cljdoc_analyzer/deps_tool.clj
@@ -1,12 +1,13 @@
 (ns ^:no-doc cljdoc-analyzer.deps-tool
   "Entry point for running as a Clojure CLI tool"
-  (:require [babashka.fs :as fs]
-            [clojure.string :as string]
-            [clojure.pprint :as pp]
-            [clojure.tools.logging :as log]
-            [cljdoc-analyzer.deps :as deps]
-            [cljdoc-analyzer.runner :as runner]
-            [cljdoc-analyzer.config :as config]))
+  (:require
+   [babashka.fs :as fs]
+   [cljdoc-analyzer.config :as config]
+   [cljdoc-analyzer.deps :as deps]
+   [cljdoc-analyzer.runner :as runner]
+   [clojure.pprint :as pp]
+   [clojure.string :as string]
+   [clojure.tools.logging :as log]))
 
 (defn- extra-repo-arg-to-option [extra-repos]
   (reduce (fn [acc n]

--- a/src/cljdoc_analyzer/main.clj
+++ b/src/cljdoc_analyzer/main.clj
@@ -1,11 +1,12 @@
 (ns ^:no-doc cljdoc-analyzer.main
-  (:require [cli-matic.core :as cli]
-            [expound.alpha :as expound]
-            [clojure.spec.alpha :as spec]
-            [clojure.string :as string]
-            [cljdoc-analyzer.config :as config]
-            [cljdoc-analyzer.deps :as deps]
-            [cljdoc-analyzer.runner :as runner]))
+  (:require
+   [cli-matic.core :as cli]
+   [cljdoc-analyzer.config :as config]
+   [cljdoc-analyzer.deps :as deps]
+   [cljdoc-analyzer.runner :as runner]
+   [clojure.spec.alpha :as spec]
+   [clojure.string :as string]
+   [expound.alpha :as expound]))
 
 (defn- extra-repo-arg-to-option [extra-repo]
   (reduce (fn [acc n]

--- a/src/cljdoc_analyzer/runner.clj
+++ b/src/cljdoc_analyzer/runner.clj
@@ -8,23 +8,25 @@
 
   By shelling out a separate process we create an isolated environment which
   does not have the dependencies of cljdoc-analyzer."
-  (:require [babashka.fs :as fs]
-            [clojure.edn :as edn]
-            [clojure.java.io :as io]
-            [clojure.java.shell :as sh]
-            [clojure.string :as string]
-            [clojure.tools.logging :as log]
-            [clojure.pprint :as pprint]
-            [clojure.spec.alpha :as s]
-            [cljdoc-analyzer.config :as config]
-            [cljdoc-analyzer.deps :as deps]
-            [cljdoc-analyzer.file :as file]
-            [cljdoc-shared.proj :as proj]
-            [cljdoc-shared.spec.analyzer :as analyzer-spec]
-            [cljdoc-shared.analysis-edn :as analysis-edn]
-            [version-clj.core :as v])
-  (:import (java.net URI)
-           (org.objectweb.asm ClassReader ClassVisitor Opcodes)))
+  (:require
+   [babashka.fs :as fs]
+   [cljdoc-analyzer.config :as config]
+   [cljdoc-analyzer.deps :as deps]
+   [cljdoc-analyzer.file :as file]
+   [cljdoc-shared.analysis-edn :as analysis-edn]
+   [cljdoc-shared.proj :as proj]
+   [cljdoc-shared.spec.analyzer :as analyzer-spec]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.java.shell :as sh]
+   [clojure.pprint :as pprint]
+   [clojure.spec.alpha :as s]
+   [clojure.string :as string]
+   [clojure.tools.logging :as log]
+   [version-clj.core :as v])
+  (:import
+   (java.net URI)
+   (org.objectweb.asm ClassReader ClassVisitor Opcodes)))
 
 ;; enable spec asserts for cljdoc-analyzer
 (s/check-asserts true)

--- a/test/integration/cljdoc_analyzer/cljdoc_main_shell_test.clj
+++ b/test/integration/cljdoc_analyzer/cljdoc_main_shell_test.clj
@@ -1,11 +1,12 @@
 (ns ^:integration cljdoc-analyzer.cljdoc-main-shell-test
   "These tests mimic the way cljdoc calls cljdoc-analyzer."
-  (:require [clojure.test :as t]
-            [clojure.java.shell :as shell]
-            [clojure.string :as string]
-            [clojure.java.io :as io]
-            [cljdoc-analyzer.test-helper :as test-helper]
-            [babashka.fs :as fs]))
+  (:require
+   [babashka.fs :as fs]
+   [cljdoc-analyzer.test-helper :as test-helper]
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.string :as string]
+   [clojure.test :as t]))
 
 (def clean-temp
   "Disable for debugging"

--- a/test/integration/cljdoc_analyzer/main_shell_test.clj
+++ b/test/integration/cljdoc_analyzer/main_shell_test.clj
@@ -1,11 +1,12 @@
 (ns ^:integration cljdoc-analyzer.main-shell-test
   "These tests do not represent the way cljdoc calls cljdoc-analyzer.
    They are here to ensure our command-line friendly adhoc interface works."
-  (:require [babashka.fs :as fs]
-            [clojure.test :as t]
-            [clojure.tools.deps :as tdeps]
-            [clojure.java.shell :as shell]
-            [cljdoc-analyzer.test-helper :as test-helper]))
+  (:require
+   [babashka.fs :as fs]
+   [cljdoc-analyzer.test-helper :as test-helper]
+   [clojure.java.shell :as shell]
+   [clojure.test :as t]
+   [clojure.tools.deps :as tdeps]))
 
 (defn- run-analysis [project version]
   (println "Analyzing" project version)

--- a/test/integration/cljdoc_analyzer/test_helper.clj
+++ b/test/integration/cljdoc_analyzer/test_helper.clj
@@ -1,9 +1,10 @@
 (ns cljdoc-analyzer.test-helper
-  (:require [babashka.fs]
-            [clojure.test :as t]
-            [clojure.java.io :as io]
-            [clojure.string :as string]
-            [cljdoc-shared.analysis-edn :as analysis-edn]))
+  (:require
+   [babashka.fs]
+   [cljdoc-shared.analysis-edn :as analysis-edn]
+   [clojure.java.io :as io]
+   [clojure.string :as string]
+   [clojure.test :as t]))
 
 (defn edn-filename [prefix project version]
   (let [project (if (string/index-of project "/")


### PR DESCRIPTION
new lint options that affected code (but not behaviour):
- sorted namespaces - this keeps the team on a single sort order which leads to better diffs
- redundant-fn-wrapper - fixed one occurrence