### PR TITLE
maint: bump deps

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,7 +10,7 @@
 
 == Unreleased
 
-*
+* Bump deps
 
 == v1.0.815
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,15 +1,15 @@
 {:paths ["src" "resources" "modules"]
- :deps {org.clojure/clojure {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.1"}
         org.clojure/tools.deps {:mvn/version "0.23.1512"}
         org.clojure/tools.logging {:mvn/version "1.3.0"}
         ch.qos.logback/logback-classic {:mvn/version "1.5.18"}
         version-clj/version-clj {:mvn/version "2.0.3"}
         cli-matic/cli-matic {:mvn/version "0.5.4"}
-        babashka/fs {:mvn/version "0.5.24"}
+        babashka/fs {:mvn/version "0.5.25"}
         org.ow2.asm/asm {:mvn/version "9.8"}
         ;; cljoc and cljdoc-analyzer should reference same version of cljdoc-shared
         cljdoc/cljdoc-shared {:git/url "https://github.com/cljdoc/cljdoc-shared.git"
-                              :git/sha "b000151410f11151999aeb0f78229db3c70ae5c9"}}
+                              :git/sha "f536a98ae8a887effde796c7f8cbbe5880f0840c"}}
  :tools/usage {:ns-default cljdoc-analyzer.deps-tool}
  :aliases {:test
            {:extra-paths ["test/integration" "test-resources"]

--- a/modules/metagetta/deps.edn
+++ b/modules/metagetta/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.12.0"}
-        org.clojure/clojurescript {:mvn/version "1.11.132"}}
+ :deps {org.clojure/clojure {:mvn/version "1.12.1"}
+        org.clojure/clojurescript {:mvn/version "1.12.42"}}
  :aliases {:test-base
            {:extra-paths ["test"]
             :extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}


### PR DESCRIPTION
Apparently this latest version of clojurescript will be able to handle older clojurescript libs due to fork&fixes of google closure.