### PR TITLE
Stub the base module for $-member JS string requires

### DIFF
--- a/modules/metagetta/src/cljdoc_analyzer/metagetta/clojurescript.clj
+++ b/modules/metagetta/src/cljdoc_analyzer/metagetta/clojurescript.clj
@@ -106,6 +106,25 @@
          (remove unreferenced-protocol?)
          (map (partial read-var source-path file vars)))))
 
+(defn- base-modules
+  "Expand JS module identifiers to also include their base module.
+
+  A string require can target a member of a JS module with the `$` separator,
+  e.g. `\"@mui/material/Button$default\"` (the form shadow-cljs and
+  ClojureScript both use to reach a default/named export). ClojureScript
+  resolves such a require against the base module before the `$`
+  (`\"@mui/material/Button\"`), so we must stub that base name too, otherwise
+  analysis fails with \"No such namespace\".
+  https://github.com/cljdoc/cljdoc-analyzer/issues/18"
+  [modules]
+  (mapcat (fn [m]
+            (let [s (str m)
+                  i (.indexOf s "$")]
+              (if (pos? i)
+                [s (subs s 0 i)]
+                [s])))
+          modules))
+
 (defn- fake-js-deps
   "Generate a value for the analyzers :js-dependency-index that 'stubs out' all JS modules
   listed in `js-dependencies`.
@@ -127,9 +146,9 @@
         npm-deps (when (map? (:npm-deps deps))
                    (keys (:npm-deps deps)))
         foreign-libs (mapcat :provides (:foreign-libs deps))]
-    (zipmap (concat js-dependencies
-                    npm-deps foreign-libs
-                    ["react" "react-dom" "cljsjs.react"])
+    (zipmap (base-modules (concat js-dependencies
+                                  npm-deps foreign-libs
+                                  ["react" "react-dom" "cljsjs.react"]))
             (repeatedly #(gensym "fake$module")))))
 
 (defn- create-compiler-state [js-dependencies]

--- a/modules/metagetta/src/cljdoc_analyzer/metagetta/clojurescript.clj
+++ b/modules/metagetta/src/cljdoc_analyzer/metagetta/clojurescript.clj
@@ -120,9 +120,8 @@
   (mapcat (fn [m]
             (let [s (str m)
                   i (.indexOf s "$")]
-              (if (pos? i)
-                [s (subs s 0 i)]
-                [s])))
+              (cond-> [s]
+                (pos? i) (conj (subs s 0 i)))))
           modules))
 
 (defn- fake-js-deps

--- a/modules/metagetta/test-sources-special/metagetta_test_special/js_default_require.cljs
+++ b/modules/metagetta/test-sources-special/metagetta_test_special/js_default_require.cljs
@@ -1,0 +1,11 @@
+(ns metagetta-test-special.js-default-require
+  "A string require that targets a JS default export via the `module$default`
+  form. ClojureScript resolves it against the base module
+  (\"some-js-lib/widget\"), which the analyzer must find stubbed in its
+  :js-dependency-index. https://github.com/cljdoc/cljdoc-analyzer/issues/18"
+  (:require ["some-js-lib/widget$default" :as Widget]))
+
+(defn make-widget
+  "Construct a Widget, referencing the default-exported JS class."
+  []
+  (Widget.))

--- a/modules/metagetta/test/cljdoc_analyzer/metagetta/specials_test.clj
+++ b/modules/metagetta/test/cljdoc_analyzer/metagetta/specials_test.clj
@@ -1,6 +1,7 @@
 (ns cljdoc-analyzer.metagetta.specials-test
   "Test various special cases, one at a time"
   (:require
+   [cljdoc-analyzer.metagetta.clojurescript :as cljs-reader]
    [cljdoc-analyzer.metagetta.main :as main]
    [clojure.test :as t]))
 
@@ -24,3 +25,25 @@
         expected {"clj" expected-ns
                   "cljs" expected-ns}]
     (t/is (= expected actual))))
+
+(t/deftest analyze-js-default-export-require-test
+  ;; Regression: a string require that reaches a JS default/named export via
+  ;; the `module$default` form must not break analysis. ClojureScript resolves
+  ;; it against the base module, which has to be stubbed in
+  ;; :js-dependency-index. https://github.com/cljdoc/cljdoc-analyzer/issues/18
+  ;;
+  ;; `all-js-requires` is redef'd because it scans the classpath via
+  ;; clojure.java.classpath, which doesn't enumerate the test's source
+  ;; *directory* under the test runner (it does enumerate jars, the real
+  ;; cljdoc input). This feeds in the require the fixture declares.
+  (let [ns 'metagetta-test-special.js-default-require]
+    (with-redefs [cljs-reader/all-js-requires
+                  (constantly #{"some-js-lib/widget$default"})]
+      (let [the-ns (->> (analyze-special-source {:languages #{"cljs"}} ns)
+                        (#(get % "cljs"))
+                        (filter #(= ns (:name %)))
+                        first)]
+        (t/is (some? the-ns)
+              "namespace with a `$default` JS require is analyzed without error")
+        (t/is (some #(= 'make-widget (:name %)) (:publics the-ns))
+              "its public var is discovered")))))


### PR DESCRIPTION
Fixes #134

## What this fixes

ClojureScript analysis throws "No such namespace" for a string require that
reaches a JS module member through the `module$member` form, such as a default
export:

```clojure
(:require ["@mui/material/Button$default" :as Button])
```

A library that hits it: `io.github.jramosg/reagent-mui-nested-menu`.

## Why it happens

`fake-js-deps` stubs each string require verbatim in `:js-dependency-index`
(the mechanism added in #18). For `"@mui/material/Button$default"` it adds that
exact key.

`cljs.analyzer/analyze-deps` resolves a `$`-member require against the base
module. It runs the dep through `lib&sublib`, keeps the first part
(`"@mui/material/Button"`), then checks whether that base name sits in
`:js-dependency-index`. Nothing stubbed the base, so the analyzer falls through
to loading it as a ClojureScript namespace and throws.

The stubbed key and the looked-up key never match.

## The change

A new `base-modules` helper expands each JS identifier to also include the part
before the first `$`. `fake-js-deps` runs its dependency list through it, so
both `"@mui/material/Button$default"` and `"@mui/material/Button"` land in the
index.

## Tests

`analyze-js-default-export-require-test` analyzes a fixture that imports a
default export via `$default`. It fails before this change with the
"No such namespace" error and passes after it.

The test redefs `all-js-requires`. That function reads the classpath through
`clojure.java.classpath`, which lists jars (the real cljdoc input) but not the
test's source directory under the test runner, so the test feeds the require in
directly.

## Checks

- `bb test` in `modules/metagetta`: 11 tests, 21 assertions, 0 failures.
- `clj-kondo`: clean.
